### PR TITLE
fix: handler悬空引用

### DIFF
--- a/Utils/RestFrame/RestWrapper.cpp
+++ b/Utils/RestFrame/RestWrapper.cpp
@@ -177,7 +177,7 @@ bool RestWrapper::registerHandler(const std::string& methodName, JsonHandler han
     };
     
     TRACE("RestWrapper::registerRoute", "registerHandler, path is " + path + ", method is " + methodName);
-    drogon::app().registerHandler(path, lambda, getConstraintFromMethodVec(httpMethods));
+    drogon::app().registerHandler(path, std::move(lambda), getConstraintFromMethodVec(httpMethods));
     return true;
 }
 


### PR DESCRIPTION
drogon::app().registerHandler 该函数的第二个参数是万能引用，传一个生命周期马上结束的值会导致处理对应请求时coredump