### PR TITLE
fix: 修复func悬空引用

### DIFF
--- a/Utils/RestFrame/RestWrapper.cpp
+++ b/Utils/RestFrame/RestWrapper.cpp
@@ -177,7 +177,7 @@ bool RestWrapper::registerHandler(const std::string& methodName, JsonHandler han
     };
     
     TRACE("RestWrapper::registerRoute", "registerHandler, path is " + path + ", method is " + methodName);
-    drogon::app().registerHandler(path, lambda, getConstraintFromMethodVec(httpMethods));
+    drogon::app().registerHandler(path, std::move(lambda), getConstraintFromMethodVec(httpMethods));
     return true;
 }
 


### PR DESCRIPTION
```c++
template <typename FUNCTION>
class HttpBinder : public HttpBinderBase
{
  public:
    ...
    HttpBinder(FUNCTION &&func) : func_(std::forward<FUNCTION>(func))
    {
        static_assert(traits::isHTTPFunction,
                      "Your API handler function interface is wrong!");
        handlerName_ = DrClassMap::demangle(typeid(FUNCTION).name());
    }
  private:
    FUNCTION func_; 
}
template <typename FUNCTION>
    HttpAppFramework &registerHandler(
        const std::string &pathPattern,
        FUNCTION &&function,
        const std::vector<internal::HttpConstraint> &constraints = {},
        const std::string &handlerName = "")
    {
        LOG_TRACE << "pathPattern:" << pathPattern;
        auto binder = std::make_shared<internal::HttpBinder<FUNCTION>>(
            std::forward<FUNCTION>(function));
        ...
    }
```
此处调用registerHandler，第二个参数传递的是一个左值，此处FUNCTION被推断成了引用，后面调用链上有func_引用着lambda，但是函数结束后lambda生命周期结束，导致悬空引用